### PR TITLE
Ensure not_if gets runs as shell command, not Ruby code.

### DIFF
--- a/cookbooks/binary/recipes/default.rb
+++ b/cookbooks/binary/recipes/default.rb
@@ -22,7 +22,7 @@ end
 node[:rvm][:binary][:versions].each do |version|
   bash "uninstall #{version}" do
     code "/usr/local/rvm/bin/rvm uninstall #{version}"
-    only_if { "rvm use #{version}" }
+    only_if "rvm use #{version}"
   end
   bash "install #{version}" do
     code "/usr/local/rvm/bin/rvm install #{version} --movable"


### PR DESCRIPTION
The conditional execution methods in a Chef resource have 2 modes: one that takes a string and one that takes a Ruby block. Here's the details:

> not_if and only_if attributes can be passed as strings or blocks.
> 
> Strings are executed as a shell command. The attribute is true if the command returns 0.
> Blocks are Ruby code. The attribute is true if the result is true.

(From the [Resources](http://wiki.opscode.com/display/chef/Resources#Resources-ConditionalExecution) wiki page)

Good stuff, thanks for this!
