### PR TITLE
use vagrant 1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
-#ruby=1.9.3-p194
-
-#gem "chef"
-gem "vagrant"
+gem "vagrant", ">= 1.1", :git => "git://github.com/mitchellh/vagrant.git"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,38 +4,41 @@ require 'yaml'
 
 distributions = YAML::load_file('distributions.yml')
 
-Vagrant::Config.run do |global_config|
+Vagrant::Config.run do |config|
   distributions.each do |name, url|
-    global_config.vm.define name.to_sym do |config|
+    config.vm.define name.to_sym do |config|
       config.vm.box = name
       config.vm.box_url = url
-      config.vm.customize [
-        "modifyvm", :id,
-        "--memory", "1024",
-        "--cpus", "2",
-        "--ioapic", "on",
-      ]
-      config.vm.provision :shell do |shell|
-        shell.inline = <<-EOF
-          [[ -s /etc/gemrc ]] && grep -- '--user-install' /etc/gemrc >/dev/null && sudo sed -i'' -- '/--user-install/ d' /etc/gemrc || true ;
-          which chef-client >/dev/null 2>&1 || sudo gem install chef --no-ri --no-rdoc --no-user-install || true ;
-          sudo sed -i'' '/^127.0.0.1[[:space:]]*localhost$/ s/$/ '"$(hostname)"'/' /etc/hosts || true ;
-        EOF
-      end
-      config.vm.provision :chef_solo do |chef|
-        chef.cookbooks_path = "cookbooks"
-        chef.add_recipe "binary"
-        chef.log_level = :debug
-        if ENV.has_key?("RUBY_VERSIONS")
-          chef.json = {
-            :rvm => {
-              :binary => {
-                :versions => ENV["RUBY_VERSIONS"].split(/ /)
-              }
-            }
+    end
+  end
+
+  config.vm.customize [
+    "modifyvm", :id,
+    "--memory", "1024",
+    "--cpus", "2",
+    "--ioapic", "on",
+  ]
+
+  config.vm.provision :shell do |shell|
+    shell.inline = <<-EOF
+      [[ -s /etc/gemrc ]] && grep -- '--user-install' /etc/gemrc >/dev/null && sudo sed -i'' -- '/--user-install/ d' /etc/gemrc || true ;
+      which chef-client >/dev/null 2>&1 || sudo gem install chef --no-ri --no-rdoc --no-user-install || true ;
+      sudo sed -i'' '/^127.0.0.1[[:space:]]*localhost$/ s/$/ '"$(hostname)"'/' /etc/hosts || true ;
+    EOF
+  end
+
+  config.vm.provision :chef_solo do |chef|
+    chef.cookbooks_path = "cookbooks"
+    chef.add_recipe "binary"
+    chef.log_level = :debug
+    if ENV.has_key?("RUBY_VERSIONS")
+      chef.json = {
+        :rvm => {
+          :binary => {
+            :versions => ENV["RUBY_VERSIONS"].split(/ /)
           }
-        end
-      end
+        }
+      }
     end
   end
 end

--- a/cookbooks/binary/recipes/default.rb
+++ b/cookbooks/binary/recipes/default.rb
@@ -55,18 +55,16 @@ end
   end
 end
 
-bash "install rvm requirements" do
-  log_code "#{rvm_command} requirements run force"
-end
-
 node[:rvm][:binary][:versions].each do |version|
   bash "uninstall #{version}" do
     log_code "#{rvm_command} uninstall #{version}"
     only_if "#{rvm_command} use #{version}"
   end
+
   bash "install #{version}" do
-    log_code "#{rvm_command} install #{version} --movable"
+    log_code "#{rvm_command} install #{version} --movable --autolibs=4"
   end
+
   bash "package #{version}" do
     cwd "/vagrant"
     log_code "#{rvm_command} prepare #{version} --path"


### PR DESCRIPTION
Once you installed vagrant 1.1+ all vagrant 1.0 projects stop working, so the only way is forward
- less indentation for vagrantfile by keeping only the different steps in the define block
- use autolibs instead of run force which just failed

@mpapis
