### PR TITLE
Fix Vagrant download url

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Automation of building binary rubies for RVM.
 
 ## Initialization
 
-Install vagrant from http://downloads.vagrantup.com/
+Install vagrant from http://www.vagrantup.com/downloads.html
 
 ## Invocation
 


### PR DESCRIPTION
The download page for Vagrant was moved to a new location, previously linked page contained only old builds.
