### PR TITLE
Update to latest Ruby 2.x versions.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,9 +1,9 @@
 binaries:
   - ruby-1.9.3-p551
-  - ruby-2.0.0-p598
-  - ruby-2.1.5
-  - ruby-2.2.0
-  - ruby-2.2.1
+  - ruby-2.0.0-p648
+  - ruby-2.1.8
+  - ruby-2.2.4
+  - ruby-2.3.0
 distributions:
   centos_59_64bit: https://atlas.hashicorp.com/boxcutter/boxes/centos59/versions/1.0.10/providers/virtualbox.box
   centos_64_64bit: https://atlas.hashicorp.com/boxcutter/boxes/centos64/versions/1.0.10/providers/virtualbox.box


### PR DESCRIPTION
I'm not sure of when or how the binaries get compiled for RVM. I thought I'd update this config the latest Rubies that have security fixes. It would be great to get Linux binaries of these uploaded so we can access them in rvm1-ansible (https://github.com/rvm/rvm1-ansible/pull/55). If I'm doing this wrong or there's anything else I can do to help, please let me know.
