### PR TITLE
Add Oracle Linux 7.2

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -24,6 +24,7 @@ distributions:
   ubuntu_1510_64bit_willy: https://atlas.hashicorp.com/ubuntu/boxes/wily64/versions/20160715.0.0/providers/virtualbox.box
   ubuntu_1604_64bit_xenial: https://atlas.hashicorp.com/ubuntu/boxes/xenial64/versions/20161221.0.0/providers/virtualbox.box
   ubuntu_1610_64bit_yakkety: https://atlas.hashicorp.com/ubuntu/boxes/yakkety64/versions/20170207.0.0/providers/virtualbox.box
+  oracle_72_64bit: https://atlas.hashicorp.com/boxcutter/boxes/ol72/versions/3.0.9/providers/virtualbox.box
 
 release_links:
   centos: http://en.wikipedia.org/wiki/CentOS#CentOS_releases

--- a/setup-vm.sh
+++ b/setup-vm.sh
@@ -31,6 +31,14 @@ then
   sed -E -i'' -e 's/(Defaults\s+requiretty)/#\1/' /etc/sudoers
 fi
 
+# Oracle
+if
+  [[ -f /etc/os-release ]] &&
+  GREP_OPTIONS="" \grep 'ID="ol"' /etc/os-release >/dev/null
+then
+  yum install libyaml-devel -y --enablerepo ol7_optional_latest
+fi
+
 groups vagrant | grep rvm >/dev/null ||
   /usr/sbin/usermod -a -G rvm vagrant
 


### PR DESCRIPTION
Add an Oracle Linux 7.2 box to the list of platforms. My hope is that this is a step toward getting binaries for Oracle Linux on https://rvm.io/binaries/

`./run oracle_72_64bit` output with these changes: https://gist.github.com/aogail/448692480c34ff3666a51afbdb0a2703