### PR TITLE
Add support for CentOS 7.3

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -7,6 +7,7 @@ binaries:
 distributions:
   centos_59_64bit: https://atlas.hashicorp.com/boxcutter/boxes/centos59/versions/1.0.10/providers/virtualbox.box
   centos_64_64bit: https://atlas.hashicorp.com/boxcutter/boxes/centos64/versions/1.0.10/providers/virtualbox.box
+  centos_73_64bit: https://atlas.hashicorp.com/boxcutter/boxes/centos73/versions/2.0.21/providers/virtualbox.box
   debian_77_32bit_wheezy: https://atlas.hashicorp.com/boxcutter/boxes/debian77-i386/versions/1.0.9/providers/virtualbox.box
   debian_77_64bit_wheezy: https://vagrantcloud.com/boxcutter/boxes/debian77/versions/1.0.9/providers/virtualbox.box
   debian_8_64bit_jessie: http://rvm.io/vboxes/debian_8_jessie_64bit.box


### PR DESCRIPTION
Include CentOS 7.3 in the list of supported operating systems. Tested
with `./run centos_73_64bit`. Checksums of built binaries:

```
$ md5 binaries/centos/7/x86_64/ruby-*
MD5 (binaries/centos/7/x86_64/ruby-1.9.3-p551.tar.bz2) = f5459880865a1b2fa152e1442a022b59
MD5 (binaries/centos/7/x86_64/ruby-2.0.0-p648.tar.bz2) = d0cee65a9cd545bf7946e15917f6575a
MD5 (binaries/centos/7/x86_64/ruby-2.1.8.tar.bz2) = 3cfdeb4b33b34b4257b29800e94743f6
MD5 (binaries/centos/7/x86_64/ruby-2.2.4.tar.bz2) = c31259b0f9523d4fea8778bf59380593
MD5 (binaries/centos/7/x86_64/ruby-2.3.0.tar.bz2) = 4f773c0c8c71afe647997dbc655de9d7
$ shasum -a 256 binaries/centos/7/x86_64/ruby-*
ec0e89cdd49ff56b3c8fcb7e3cb85fa241f8040235e72272d517134e60486012  binaries/centos/7/x86_64/ruby-1.9.3-p551.tar.bz2
34e77f3fbb3525cf855582f4b707e30faa64af1f53eb090a10238742a019379e  binaries/centos/7/x86_64/ruby-2.0.0-p648.tar.bz2
30c0670a11e4d00a141f978619dc554faa01cff93f7c9093477cbd7dd2874bff  binaries/centos/7/x86_64/ruby-2.1.8.tar.bz2
caf849ecbaf6e7d8239c12ec84d6c17b55d53fccb40f7a1fe67e9898dfe6749f  binaries/centos/7/x86_64/ruby-2.2.4.tar.bz2
0037f995d54b43ff0d8cd513ab554d55a46fe2297574ec5f22aa3ad58091c7da  binaries/centos/7/x86_64/ruby-2.3.0.tar.bz2
```

See rvm/rvm#3942